### PR TITLE
Add LICENSE file and update README files for clarity and consistency

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [2025] Foxbit Serviços Digitais Ltda.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/rest-v3-sdk/README.md
+++ b/rest-v3-sdk/README.md
@@ -1,6 +1,6 @@
-# Foxbit Exchange API Examples
+# Foxbit SDK Examples
 
-This repository demonstrates how the Foxbit exchange API works, showcasing various operations such as fetching market data, placing orders, and managing accounts. It serves as a guide for developers who want to integrate Foxbit's exchange functionality into their applications.
+This repository contains examples demonstrating how to use the official Foxbit SDK to interact with the Foxbit exchange API. The examples cover various operations such as fetching market data, placing orders, and managing accounts using the SDK. This is intended as a guide for developers who want to integrate Foxbit's exchange functionality into their applications using the SDK.
 
 ## Features
 
@@ -24,8 +24,7 @@ git clone git@github.com:foxbit-group/foxbit-api-samples.git
 cd foxbit-api-samples
 ```
 
-Now you can choose one language to start. Each one has your own README file that explains how run the code.
-Please pay attention to the requirements.
+Now you can choose one language to start. Each folder contains examples using the Foxbit SDK. Please refer to the respective README file in each folder for instructions and requirements.
 
 ## Contributing
 


### PR DESCRIPTION
This pull request introduces a new `LICENSE.md` file with the MIT license, updates the `README.md` files for two directories (`rest-v3-sdk` and `rest-v3`), and makes minor corrections to improve clarity and consistency. Below is a summary of the most important changes grouped by theme.

### Licensing:
* Added a new `LICENSE.md` file with the MIT license, specifying terms and conditions for using the software.

### Documentation Updates:
* Created a new `README.md` file in the `rest-v3-sdk` directory, providing examples and instructions for using the Foxbit SDK to interact with the Foxbit exchange API.
* Updated the `README.md` file in the `rest-v3` directory to align its content with Foxbit branding and clarify its purpose as a guide for using the Foxbit exchange API.

### Minor Fixes:
* Corrected a typo in the `rest-v3/README.md` file where "READme" was updated to "README" for consistency.
* Updated the license link in the `rest-v3/README.md` file to correctly reference the new `LICENSE.md` file in the parent directory.