### PR TITLE
Update examples to reflect order cancellation instead of order book retrieval

### DIFF
--- a/rest-v3-sdk/javascript/examples.js
+++ b/rest-v3-sdk/javascript/examples.js
@@ -46,7 +46,7 @@ function sleep(ms) {
     });
     console.log("Response:", ordersResponse.data);
 
-    // Request to get the order book
+    // Request to cancel the order
     const cancelResponse = await tradingApi.cancelOrders({
       cancelOrdersRequest: {
         type: "ID",

--- a/rest-v3-sdk/typescript/examples.ts
+++ b/rest-v3-sdk/typescript/examples.ts
@@ -46,7 +46,7 @@ function sleep(ms: number): Promise<void> {
     });
     console.log("Response:", ordersResponse.data);
 
-    // Request to get the order book
+    // Request to cancel the order
     const cancelResponse = await tradingApi.cancelOrders({
       cancelOrdersRequest: {
         type: "ID",

--- a/rest-v3/typescript/examples.ts
+++ b/rest-v3/typescript/examples.ts
@@ -95,7 +95,7 @@ function sleep(ms: number): Promise<void> {
     const ordersResponse = await request('GET', '/rest/v3/orders', ordersParam);
     console.log('Response:', ordersResponse.data);
 
-    // Request to get the order book
+    // Request to cancel the order
     const orderToCancel = {
       type: 'ID',
       id: orderResponse.data.id


### PR DESCRIPTION
This pull request updates comments in example files for JavaScript and TypeScript to correctly describe the API request being made. Specifically, it changes the description from "Request to get the order book" to "Request to cancel the order" to align with the actual functionality of the code.

Comment updates for API request descriptions:

* [`rest-v3-sdk/javascript/examples.js`](diffhunk://#diff-55f852681923c77705ecd1f3a72d85ecda1026d126399460ddbb6d90473dbf43L49-R49): Updated the comment to correctly describe the API request as canceling an order instead of fetching the order book.
* [`rest-v3-sdk/typescript/examples.ts`](diffhunk://#diff-d2e3cada491de77632cfeaf3f2a702f9e78d2372f4a41e14a567d1b63f30b04cL49-R49): Updated the comment to correctly describe the API request as canceling an order instead of fetching the order book.
* [`rest-v3/typescript/examples.ts`](diffhunk://#diff-d150d13dc7628f333fdae6f1432e9c5524c923d89fa2edf61fe5d409b55db6a0L98-R98): Updated the comment to correctly describe the API request as canceling an order instead of fetching the order book.