### PR TITLE
fix: update order book subscription value to 100ms and add README

### DIFF
--- a/websocket-v3/javascript/README.md
+++ b/websocket-v3/javascript/README.md
@@ -31,9 +31,9 @@ This WebSocket v3 example provides:
 - **Interactive Menu**: Choose between different data channels using an interactive command-line menu
 - **Channel Subscriptions**:
   - **Trades**: Real-time trade executions
-  - **Order Book**: Live order book updates (1000 levels)
+  - **Order Book**: Live order book updates (100 miliseconds interval)
   - **Ticker**: 24h market statistics
-  - **Candles**: OHLCV candlestick data (60-minute intervals)
+  - **Candles**: OHLCV candlestick data (60-seconds interval)
 - **Automatic Ping/Pong**: Maintains connection with periodic ping messages
 - **Comprehensive Logging**: All WebSocket messages are logged to timestamped files in the `logs/` directory
 - **Real-time Log Monitoring**: Follow logs in real-time using `tail -f logs/[filename]`
@@ -45,7 +45,7 @@ The example demonstrates subscription to the following channels for the BTC/BRL 
 - `trades` - Real-time trade executions
 - `orderbook-100` - Order book updates with 100 miliseconds intervals
 - `ticker` - 24-hour market statistics
-- `candles-60` - Candlestick data with 60-seconds intervals
+- `candles-60` - Candlestick data with 60-seconds interval
 
 ## Log Files
 

--- a/websocket-v3/javascript/README.md
+++ b/websocket-v3/javascript/README.md
@@ -1,0 +1,60 @@
+# Foxbit API WebSocket v3 JavaScript Examples
+
+Here are the JavaScript examples for the Foxbit API WebSocket v3. This section provides an interactive script to help you understand how to interact with the Foxbit WebSocket using JavaScript. These examples cover real-time market data subscription, including trades, order book, ticker, and candles data.
+
+## Prerequisites
+
+Before you begin, ensure you have the following prerequisites installed on your system:
+
+- **Node.js**: These examples are written for Node.js, a JavaScript runtime built on Chrome's V8 JavaScript engine. Ensure you have the latest stable version installed.
+- **NPM (Node Package Manager)**: Comes with Node.js, used for managing dependencies.
+
+## Getting Started
+
+1. **Install Dependencies**: Navigate to the JavaScript examples directory in your terminal and run `npm install` to install the necessary dependencies.
+
+   ```bash
+   npm install
+   ```
+
+2. **Running the Examples**: To run the example, navigate to the project directory in the terminal and execute the following command:
+
+   ```bash
+   npm start
+   ```
+
+## Features
+
+This WebSocket v3 example provides:
+
+- **Real-time Market Data**: Subscribe to live market data feeds
+- **Interactive Menu**: Choose between different data channels using an interactive command-line menu
+- **Channel Subscriptions**:
+  - **Trades**: Real-time trade executions
+  - **Order Book**: Live order book updates (1000 levels)
+  - **Ticker**: 24h market statistics
+  - **Candles**: OHLCV candlestick data (60-minute intervals)
+- **Automatic Ping/Pong**: Maintains connection with periodic ping messages
+- **Comprehensive Logging**: All WebSocket messages are logged to timestamped files in the `logs/` directory
+- **Real-time Log Monitoring**: Follow logs in real-time using `tail -f logs/[filename]`
+
+## Available Channels
+
+The example demonstrates subscription to the following channels for the BTC/BRL market:
+
+- `trades` - Real-time trade executions
+- `orderbook-100` - Order book updates with 100 miliseconds intervals
+- `ticker` - 24-hour market statistics
+- `candles-60` - Candlestick data with 60-seconds intervals
+
+## Log Files
+
+All WebSocket communications are automatically logged to timestamped files in the `logs/` directory. When you start the application, it will display the log filename and provide a command to follow logs in real-time:
+
+```bash
+tail -f logs/websocket-logs-[timestamp].log
+```
+
+## Additional Notes
+
+These examples are meant to serve as a starting point. They demonstrate basic WebSocket v3 interactions for public market data. The connection uses the public WebSocket endpoint and doesn't require authentication. It's recommended to review and test the code thoroughly before using it in a production environment. For detailed API documentation, refer to the [Foxbit API Documentation](https://docs.foxbit.com.br/).

--- a/websocket-v3/javascript/README.md
+++ b/websocket-v3/javascript/README.md
@@ -31,7 +31,7 @@ This WebSocket v3 example provides:
 - **Interactive Menu**: Choose between different data channels using an interactive command-line menu
 - **Channel Subscriptions**:
   - **Trades**: Real-time trade executions
-  - **Order Book**: Live order book updates (100 miliseconds interval)
+  - **Order Book**: Live order book updates (100 milliseconds interval)
   - **Ticker**: 24h market statistics
   - **Candles**: OHLCV candlestick data (60-seconds interval)
 - **Automatic Ping/Pong**: Maintains connection with periodic ping messages
@@ -43,7 +43,7 @@ This WebSocket v3 example provides:
 The example demonstrates subscription to the following channels for the BTC/BRL market:
 
 - `trades` - Real-time trade executions
-- `orderbook-100` - Order book updates with 100 miliseconds intervals
+- `orderbook-100` - Order book updates with 100 milliseconds intervals
 - `ticker` - 24-hour market statistics
 - `candles-60` - Candlestick data with 60-seconds interval
 

--- a/websocket-v3/javascript/index.mjs
+++ b/websocket-v3/javascript/index.mjs
@@ -126,7 +126,7 @@ async function handleChannelChoice() {
         { name: 'Subscribe Trades', value: subscribeMessage('trades') },
         {
           name: 'Subscribe Order Book',
-          value: subscribeMessage('orderbook-1000'),
+          value: subscribeMessage('orderbook-100'),
         },
         { name: 'Subscribe Ticker', value: subscribeMessage('ticker') },
         { name: 'Subscribe Candles', value: subscribeMessage('candles-60') },
@@ -145,7 +145,7 @@ async function handleChannelChoice() {
         { name: 'Unsubscribe Trades', value: unsubscribeMessage('trades') },
         {
           name: 'Unsubscribe Order Book',
-          value: unsubscribeMessage('orderbook-1000'),
+          value: unsubscribeMessage('orderbook-100'),
         },
         { name: 'Unsubscribe Ticker', value: unsubscribeMessage('ticker') },
         {


### PR DESCRIPTION

This pull request adds comprehensive documentation and corrects the channel naming in the JavaScript WebSocket v3 example for Foxbit. The most significant changes include introducing a detailed `README.md` to guide users through setup and usage, and fixing the order book channel name in the interactive menu to match the correct API specification.

**Documentation Improvements:**

* Added a detailed `README.md` to the `websocket-v3/javascript/` directory, covering prerequisites, setup instructions, available channels, logging, and additional notes for using the Foxbit WebSocket v3 JavaScript examples.

**Channel Naming Corrections:**

* Updated the order book subscription and unsubscription options in `index.mjs` to use `orderbook-100` instead of the incorrect `orderbook-1000`, ensuring consistency with the documented API and example usage. [[1]](diffhunk://#diff-4767dae1d03d8ae9e5a14260b5bbaab2dda76e9417ddb8a6892ed492f7f82520L129-R129) [[2]](diffhunk://#diff-4767dae1d03d8ae9e5a14260b5bbaab2dda76e9417ddb8a6892ed492f7f82520L148-R148)